### PR TITLE
add untested /pokemon command

### DIFF
--- a/ofensivaria/commands.py
+++ b/ofensivaria/commands.py
@@ -404,6 +404,24 @@ class ConvertCurrency(Command):
             return 'Could not get value for currency %s' % symbol
 
 
+class PokeCard(Command):
+    """ Returns the image URL of a random Pokémon card.
+    The default preview system is used to display the image.
+    https://docs.pokemontcg.io/
+    Possible improvements: use the same API for searching.
+    """
+
+    SLASH_COMMAND = '/pokemon'
+
+    async def respond(self, text, message):
+        _, json = await self.http_get('https://api.pokemontcg.io/v1/cards?random=true&pageSize=1')
+
+        if not json or 'error' in json:
+            return "Spellfire will be reprinted!"
+
+        return json['cards'][0]['imageUrlHiRes']
+
+
 class Sandstorm(Command):
 
     SLASH_COMMAND = '/sandstorm'


### PR DESCRIPTION
Turns out the guy behind the M:tG API also has a similar Pokémon TCG API.